### PR TITLE
[decoder] Fixed hang

### DIFF
--- a/src/executors/src/mfx_gst_executor_vdec.cpp
+++ b/src/executors/src/mfx_gst_executor_vdec.cpp
@@ -454,15 +454,13 @@ void mfxGstPluginVdecData::DecodeFrameAsync()
         bst_ref = input_data->bst_ref;
         input_queue_.pop_front();
         loader.LoadBuffer(bst_ref, false);
+        bst = fc_->GetMfxBitstream();
       }
-      bst = fc_->GetMfxBitstream();
-      if (!bst->DataLength) {
-        if (is_eos_) {
-          bst = NULL;
-        }
-        else {
+      // No more data in the queue
+      else if (is_eos_) {
+          bst = nullptr;
+      } else {
           break;
-        }
       }
     }
 


### PR DESCRIPTION
Decoder may not consume all bistream data
in case of not COMPLETE_FRAME mode.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>